### PR TITLE
Minimalist Mode, Cover Cursor and Spinning Album Cover

### DIFF
--- a/components/Player.jsx
+++ b/components/Player.jsx
@@ -17,7 +17,7 @@ const PanelSubtext = AsyncComponent.fromDisplayName('PanelSubtext');
 const Tooltip = AsyncComponent.fromDisplayName('Tooltip');
 
 const Player = memo(props => {
-  const { devices, currentTrack, playerState, base, extraClasses, getSetting, updateSetting, reinject } = props;
+  const { devices, currentTrack, playerState, base, extraClasses, getSetting, updateSetting, reinject, minimalist, coverCursor, spinningAlbumCover } = props;
   const [ , setSeeking ] = useState(null);
   const advertisement = Boolean(playerState.currentlyPlayingType === 'ad');
 
@@ -163,7 +163,7 @@ const Player = memo(props => {
                     <img
                       {...props}
                       src={currentTrack.cover || SPOTIFY_DEFAULT_IMAGE}
-                      className={joinClassNames('spotify-in-discord-player-album-cover', avatar)}
+                      className={joinClassNames('spotify-in-discord-player-album-cover', avatar, spinningAlbumCover ? 'spinning-album-cover' : '')}
                       width='32'
                       height='32'
                     />
@@ -185,8 +185,8 @@ const Player = memo(props => {
   return (
     devices?.length === 0 || !currentTrack
       ? null
-      : <div className={`spotify-in-discord-player ${extraClasses?.join(' ')}`}>
-        {renderFromBase()}
+      : <div className={`${minimalist ? 'minimalist' : ''} spotify-in-discord-player ${extraClasses?.join(' ')}`}>
+        {minimalist ? null : renderFromBase()}
         <SeekBar
           disabled={playerState.currentlyPlayingType === 'ad'}
           isPlaying={playerState.playing}
@@ -201,6 +201,9 @@ const Player = memo(props => {
               playing: false
             });
           }}
+          minimalist={minimalist}
+          coverCursor={coverCursor}
+          coverSrc={currentTrack.cover || SPOTIFY_DEFAULT_IMAGE}
         />
       </div>
   );

--- a/components/SeekBar.jsx
+++ b/components/SeekBar.jsx
@@ -127,20 +127,20 @@ export default class SeekBar extends PureComponent {
   });
 
     return (
-      <div className='spotify-in-discord-player-seek'>
-        <div className='spotify-in-discord-player-seek-elements'>
+      <div className={`${this.props.minimalist ? "minimalist" : ""} spotify-in-discord-player-seek`}>
+        <div className={`${this.props.minimalist ? "minimalist" : ""} spotify-in-discord-player-seek-elements`}>
           <span className='spotify-in-discord-player-seek-duration'>
             {formatTime(progress)}
           </span>
-          {this.props.children}
           <span className='spotify-in-discord-player-seek-duration'>
             {formatTime(this.props.duration)}
           </span>
         </div>
-        <div className='spotify-in-discord-player-seek-bar' onMouseDown={e => this.startSeek(e)}>
+        <div className={`${this.props.minimalist ? "minimalist" : ""} spotify-in-discord-player-seek-bar`} onMouseDown={e => this.startSeek(e)}>
           <span className='spotify-in-discord-player-seek-bar-progress' style={{ width: `${current}%` }}/>
-          <span className='spotify-in-discord-player-seek-bar-cursor' style={{ left: `${current}%` }}/>
+          {this.props.coverCursor ? <img className='spotify-in-discord-player-seek-bar-cursor' src={this.props.coverSrc} style={{ left: `${current}%` }} /> : <soan className='spotify-in-discord-player-seek-bar-cursor' style={{ left: `${current}%` }} /> }
         </div>
+          {this.props.children}
       </div>
     );
   }

--- a/components/Settings.jsx
+++ b/components/Settings.jsx
@@ -52,6 +52,50 @@ export default memo(({ getSetting, updateSetting, toggleSetting, patch, reinject
           }
         }
       ></SelectInput>
+      <SwitchItem
+        note={`Minimalizes the size of the player until hovered over`}
+        value={getSetting('minimalist', false)}
+        onChange={() => {
+          toggleSetting('minimalist');
+          reinject();
+        }}
+      >
+        Minimalist Mode
+      </SwitchItem>
+      <SwitchItem
+        note={`Makes the cursor of the seek-bar the album cover`}
+        value={getSetting('cover-cursor', false)}
+        onChange={() => {
+          toggleSetting('cover-cursor');
+          reinject();
+        }}
+      >
+        Cover Cursor
+      </SwitchItem>
+      <SwitchItem
+        note={`Makes the album cover image spin at a certain speed`}
+        value={getSetting('spinning-album-cover', false)}
+        onChange={() => {
+          toggleSetting('spinning-album-cover');
+          reinject();
+        }}
+      >
+        Spinning Album Cover
+      </SwitchItem>
+      <SliderInput
+        note='Changes the speed the cover image spins at.'
+        initialValue={20}
+        maxValue={120}
+        minValue={1}
+        defaultValue={getSetting('spinSpeed', 20)}
+        onValueChange={v => {
+          v = Math.floor(v);
+          updateSetting('spinSpeed', v);
+          document.body.style.setProperty('--spotify-in-discord__player-album-spin-speed', `${v}`);
+        }}
+      >
+        Change Album Cover Spin Speed (in RPM)
+      </SliderInput>
     </div>
   );
 });

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ export default class SpotifyInDiscord extends Plugin {
     this._handleSpotifyData = this._handleSpotifyData.bind(this);
     this.ponged = false;
     this.position = this.settings.get('player-position', 'channel-list')
+    this.minimalist = this.settings.get('minimalist', false);
     // hacky workaround to get the websocket
     this.originalSend = WebSocket.prototype.send;
     this.socket = null;
@@ -80,6 +81,9 @@ export default class SpotifyInDiscord extends Plugin {
   async _injectPlayer () {
     await sleep(1e3); // It ain't stupid if it works
     this.position = this.settings.get('player-position', 'channel-list')
+    this.minimalist = this.settings.get('minimalist', false);
+    this.coverCursor = this.settings.get('cover-cursor', false);
+    this.spinningAlbumCover = this.settings.get('spinning-album-cover', false);
     const { container } = getModule('container', 'usernameContainer');
     const accountContainer = await waitForElement(`section > .${container}`);
     const instance = getOwnerInstance(accountContainer);
@@ -94,6 +98,9 @@ export default class SpotifyInDiscord extends Plugin {
       base: this.realRes,
       getSetting: this.settings.get,
       updateSetting: this.settings.set,
+      minimalist: this.minimalist,
+      coverCursor: this.coverCursor,
+      spinningAlbumCover: this.spinningAlbumCover,
     }
     if (this.position === 'channel-list') {
       await patch('spotify-in-discord-player', instance.__proto__, 'render', (_, res) => {

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -6,6 +6,7 @@
 :root {
   --spotify-in-discord__end: 100%;
   --spotify-in-discord__player-album-border-radius: 50%;
+  --spotify-in-discord__player-album-spin-speed: 20;
   --spotify-in-discord__progress: 50%;
   --spotify-in-discord__duration: 10s;
   --spotify-in-discord__spotify-brand-color: #1ed760;
@@ -172,11 +173,7 @@
   margin-bottom: -10px;
   border-bottom: solid;
   border-width: 10px;
-  @if --navdrawer-color != null {
-    border-color: var(--navdrawer-color);
-  } @else {
-    border-color: var(--background-secondary)
-  }
+  border-color: var(--background-secondary)
 }
 
 .spotify-in-discord-player.bottom {
@@ -186,12 +183,8 @@
   padding-top: 10px;
   margin-top: -10px;
   border-bottom: solid;
-  border-width: 15px;
-  @if --navdrawer-color != null {
-    border-color: var(--navdrawer-color);
-  } @else {
-    border-color: var(--background-secondary)
-  }
+  border-width: 22px;
+  border-color: var(--background-secondary)
 }
 
 @keyframes seekbar-progress-movement {
@@ -209,5 +202,28 @@
   }
   to {
     left: var(--spotify-in-discord__end);
+  }
+}
+
+.minimalist {
+  height: 100%;
+}
+
+.spotify-in-discord-player.minimalist {
+  width: 100%;
+  height: 10px !important;
+}
+
+.spinning-album-cover {
+  animation: spin linear infinite;
+  animation-duration: calc(60s / var(--spotify-in-discord__player-album-spin-speed));
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0);
+  }
+  to {
+    transform: rotate(360deg);
   }
 }


### PR DESCRIPTION
Added Minimalist mode:
- Works in all 3 locations
- Makes the player be gone and only shows the SeekBar
- Is toggleable in settings

Cover Cursor:
- The cursor thing that shows at which point the song is in the SeekBar is now replaced with the album cover
- Is toggleable in settings

Spinning Album Cover:
- Make the Album Cover spin
- Spinning speed can be changed with a separate slider
- Is toggleable in settings
- NOTE: best used with a round Album Cover, although this does work with more square ones, it'll look incredibly weird